### PR TITLE
Replaced sns.tsplot with sns.lineplot

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -1491,7 +1491,7 @@
    "source": [
     "x = random.randn(10,500)\n",
     "x = gaussian_filter(x, [0, 10])\n",
-    "sns.tsplot(x, err_style='unit_traces');"
+    "sns.lineplot(data=x.T,dashes=False,legend=None);"
    ]
   },
   {


### PR DESCRIPTION
tsplot has been removed from seaborn as of version 0.10.0. Lineplot is the recommend function to use as its replacement.